### PR TITLE
refactor autoscan database

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "python.linting.pylintEnabled": true,
     "python.linting.pylintArgs": [
         "--disable",
-        "C0103,C0114,C0115,C0116,C0301,C0413,W0703,E1120,R0903",
+        "C0103,C0114,C0115,C0116,C0301,C0413,W0703,E1120,R0903,E1101",
     ],
     "python.formatting.provider": "black",
     "python.formatting.blackArgs": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "python.linting.pylintEnabled": true,
     "python.linting.pylintArgs": [
         "--disable",
-        "C0103,C0114,C0115,C0116,C0301,C0413,W0703,E1120",
+        "C0103,C0114,C0115,C0116,C0301,C0413,W0703,E1120,R0903",
     ],
     "python.formatting.provider": "black",
     "python.formatting.blackArgs": [

--- a/autoscan/__main__.py
+++ b/autoscan/__main__.py
@@ -257,7 +257,7 @@ def api_call():
             if not conf.configs["SERVER_USE_SQLITE"]:
                 # return error if SQLITE db is not enabled
                 return jsonify({"success": False, "msg": "SERVER_USE_SQLITE must be enabled"})
-            return jsonify({"success": True, "queue_count": db.get_queue_count()})
+            return jsonify({"success": True, "queue_count": db.queued_count()})
         if cmd == "reset_page_token":
             if manager is None:
                 return jsonify({"success": False, "msg": "Google Drive monitoring is not enabled"})
@@ -436,9 +436,6 @@ def main():
         process_menu(conf.args["cmd"])
     except KnownException as e:
         logger.error(e)
-        sys.exit(1)
-    except Exception as e:
-        logger.exception(e)
         sys.exit(1)
 
 

--- a/autoscan/__main__.py
+++ b/autoscan/__main__.py
@@ -125,7 +125,7 @@ def start_scan(path: str, request_from: str, event_type: str) -> bool:
         is_added, db_item = ScanItem.get_or_add(**scan_item)
         if is_added:
             logger.debug("Added '%s' to Autoscan database.", path)
-        else:
+        elif db_item:
             logger.info(
                 "Already processing '%s' from same folder. Skip adding extra scan request to the queue.", db_item.path
             )
@@ -295,7 +295,7 @@ def client_pushed():
         isfile, action, paths = utils.parse_watcher_event(data["pipe"])
         if isfile and action in ("CREATE", "MOVE", "REMOVE"):
             for path in paths:
-                start_scan(path, event, event)
+                start_scan(path, event, action)
 
     elif "series" in data and event == "Rename" and "path" in data["series"]:
         # sonarr Rename webhook

--- a/autoscan/__main__.py
+++ b/autoscan/__main__.py
@@ -10,8 +10,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 
 # Get config
 from autoscan.config import Config
-from autoscan.threads import Thread, PriorityLock
-
+from autoscan.threads import PriorityLock, Thread
 
 ############################################################
 # INIT
@@ -69,9 +68,9 @@ scan_lock = PriorityLock()
 resleep_paths = []
 
 # local imports
-from autoscan import plex, utils, rclone
+from autoscan import plex, rclone, utils
 from autoscan.db import ScanItem
-from autoscan.drive import GoogleDriveManager, Cache
+from autoscan.drive import Cache, GoogleDriveManager
 
 manager = None
 

--- a/autoscan/config.py
+++ b/autoscan/config.py
@@ -1,14 +1,14 @@
 import argparse
+import errno
 import json
 import logging
 import os
 import sys
-import errno
 from copy import copy
 from pathlib import Path
 
-from autoscan import __version__, __title__, __description__, __url__
-from autoscan.defaults import base_settings, base_config
+from autoscan import __description__, __title__, __url__, __version__
+from autoscan.defaults import base_config, base_settings
 
 logger = logging.getLogger("CONFIG")
 

--- a/autoscan/db.py
+++ b/autoscan/db.py
@@ -32,7 +32,9 @@ class ScanItem(BaseModel):
     def init(cls, path: str) -> None:
         if path is None:
             path = ":memory:"
-            logger.warning("You are using an in-memory database as Autoscan queue.")
+            logger.warning(
+                "You are using an in-memory database as Autoscan queue. Consider using a file-based one by specifying `--queuefile` arg in CLI."
+            )
         database = pw.SqliteDatabase(path)
         ScanItem.migrate_from_legacy_to_v1(database)
         cls.bind(database)

--- a/autoscan/db.py
+++ b/autoscan/db.py
@@ -1,21 +1,22 @@
-import logging
 import os
+import time
+import logging
 from typing import Tuple
 
-from peewee import Model, SqliteDatabase, CharField, IntegerField
+import peewee as pw
 
 logger = logging.getLogger("DB")
 
 
-class QueueItemModel(Model):
-    scan_path = CharField(max_length=256, unique=True, null=False)
-    scan_for = CharField(max_length=64, null=False)
-    scan_section = IntegerField(null=False)
-    scan_type = CharField(max_length=64, null=False)
+class QueueItemModel(pw.Model):
+    scan_path = pw.CharField(max_length=256, unique=True, null=False)
+    scan_for = pw.CharField(max_length=64, null=False)
+    scan_section = pw.IntegerField(null=False)
+    scan_type = pw.CharField(max_length=64, null=False)
 
     @classmethod
     def init(cls, path: str) -> None:
-        database = SqliteDatabase(path)
+        database = pw.SqliteDatabase(path)
         cls.bind(database)
         if not os.path.exists(path):
             database.create_tables([cls])
@@ -24,42 +25,39 @@ class QueueItemModel(Model):
             database.connect()
 
     @classmethod
-    def exists_file_root_path(cls, file_path: str) -> Tuple[bool, str]:
+    def get_or_add(cls, **kwargs) -> Tuple[bool, pw.Model]:
+        """add item if its scan path does not exist in db"""
+        file_path = kwargs.pop("scan_path")
         dir_path = os.path.dirname(file_path) if "." in file_path else file_path
-        for item in QueueItemModel.select():
+        for item in cls.select():
             if dir_path.lower() in item.scan_path.lower():
-                return True, item.scan_path
-        return False, None
+                return False, item
+
+        try:
+            with cls._meta.database.atomic():
+                return True, cls.create(**kwargs)
+        except pw.IntegrityError:
+            logger.error("Scan path '%s' already exists.", file_path)
+            return False, None
+        except Exception:
+            logger.exception("Exception adding '%s' to database:", file_path)
+            return False, None
 
     @classmethod
-    def add_item(cls, scan_path, scan_for, scan_section, scan_type):
-        item = None
+    def delete_by_path(cls, path: str, loglevel: int = logging.INFO) -> bool:
         try:
-            return QueueItemModel.create(
-                scan_path=scan_path,
-                scan_for=scan_for,
-                scan_section=scan_section,
-                scan_type=scan_type,
-            )
-        except AttributeError:
-            return item
+            cls.delete().where(cls.scan_path == path).execute()
+            logger.log(loglevel, "Removed '%s' from Autoscan database.", path)
+            time.sleep(1)
+            return True
         except Exception:
-            pass
-            # logger.exception("Exception adding %r to database: ", scan_path)
-        return item
-
-    @classmethod
-    def delete_by_scan_path(cls, scan_path):
-        try:
-            return cls.delete().where(QueueItemModel.scan_path == scan_path).execute()
-        except Exception:
-            logger.exception("Exception deleting %r from Autoscan database: ", scan_path)
+            logger.exception("Exception deleting '%s' from Autoscan database:", path)
             return False
 
     @classmethod
-    def count_all(cls):
+    def count(cls) -> int:
         try:
-            return QueueItemModel.select().count()
+            return cls.select().count()
         except Exception:
-            logger.exception("Exception retrieving queued count: ")
-        return 0
+            logger.exception("Exception retrieving queued count:")
+            return 0

--- a/autoscan/db.py
+++ b/autoscan/db.py
@@ -14,16 +14,14 @@ db_path = conf.settings["queuefile"]
 database = SqliteDatabase(db_path)
 
 
-class BaseQueueModel(Model):
-    class Meta:
-        database = database
-
-
-class QueueItemModel(BaseQueueModel):
+class QueueItemModel(Model):
     scan_path = CharField(max_length=256, unique=True, null=False)
     scan_for = CharField(max_length=64, null=False)
     scan_section = IntegerField(null=False)
     scan_type = CharField(max_length=64, null=False)
+
+    class Meta:
+        database = database
 
 
 def connect(db):
@@ -37,16 +35,6 @@ def init(db, path):
         db.create_tables([QueueItemModel])
         logger.info("Created Autoscan database tables.")
     connect(db)
-
-
-def get_next_item():
-    item = None
-    try:
-        item = QueueItemModel.get()
-    except Exception:
-        # logger.exception("Exception getting first item to scan: ")
-        pass
-    return item
 
 
 def exists_file_root_path(file_path):
@@ -78,15 +66,6 @@ def get_all_items():
         logger.exception("Exception getting all items from Autoscan database: ")
         return None
     return items
-
-
-def get_queue_count():
-    count = 0
-    try:
-        count = QueueItemModel.select().count()
-    except Exception:
-        logger.exception("Exception getting queued item count from Autoscan database: ")
-    return count
 
 
 def remove_item(scan_path):

--- a/autoscan/db.py
+++ b/autoscan/db.py
@@ -1,8 +1,8 @@
+import logging
 import os
 import time
-import logging
-from typing import Tuple
 from datetime import datetime
+from typing import Tuple
 
 import peewee as pw
 from peewee import fn

--- a/autoscan/db.py
+++ b/autoscan/db.py
@@ -30,6 +30,9 @@ class ScanItem(BaseModel):
 
     @classmethod
     def init(cls, path: str) -> None:
+        if path is None:
+            path = ":memory:"
+            logger.warning("You are using an in-memory database as Autoscan queue.")
         database = pw.SqliteDatabase(path)
         ScanItem.migrate_from_legacy_to_v1(database)
         cls.bind(database)
@@ -81,7 +84,7 @@ class ScanItem(BaseModel):
             return 0
 
     @staticmethod
-    def migrate_from_legacy_to_v1(database: pw.SqliteDatabase):
+    def migrate_from_legacy_to_v1(database: pw.SqliteDatabase) -> None:
         migrator = SqliteMigrator(database)
         try:
             with database.atomic():

--- a/autoscan/defaults.py
+++ b/autoscan/defaults.py
@@ -14,11 +14,7 @@ base_settings = {
         "env": "PLEX_AUTOSCAN_LOGLEVEL",
         "default": "INFO",
     },
-    "queuefile": {
-        "argv": "--queuefile",
-        "env": "PLEX_AUTOSCAN_QUEUEFILE",
-        "default": str(Path.cwd().joinpath("queue.db")),
-    },
+    "queuefile": {"argv": "--queuefile", "env": "PLEX_AUTOSCAN_QUEUEFILE", "default": None},
     "cachefile": {
         "argv": "--cachefile",
         "env": "PLEX_AUTOSCAN_CACHEFILE",
@@ -52,7 +48,6 @@ base_config = {
     "SERVER_FILE_CHECK_DELAY": 60,
     "SERVER_FILE_EXIST_PATH_MAPPINGS": {},
     "SERVER_IGNORE_LIST": [],
-    "SERVER_USE_SQLITE": False,
     "SERVER_SCAN_PRIORITIES": {},
     "SERVER_SCAN_FOLDER_ON_FILE_EXISTS_EXHAUSTION": False,
     "RCLONE": {

--- a/autoscan/drive.py
+++ b/autoscan/drive.py
@@ -1,10 +1,10 @@
+import json
 import logging
 import os
 import sys
-import json
 from copy import copy
 
-from google.oauth2 import service_account, credentials
+from google.oauth2 import credentials, service_account
 from googleapiclient.discovery import build
 from sqlitedict import SqliteDict
 

--- a/autoscan/plex.py
+++ b/autoscan/plex.py
@@ -89,9 +89,8 @@ def scan(config, lock, resleep_paths: list, path: str, request_from: str, sectio
 
         elif checks >= config["SERVER_MAX_FILE_CHECKS"]:
             logger.warning("File '%s' exhausted all available checks. Aborting scan request.", check_path)
-            # remove item from database if sqlite is enabled
-            if config["SERVER_USE_SQLITE"]:
-                ScanItem.delete_by_path(path)
+            # remove item from database
+            ScanItem.delete_by_path(path)
             return
 
         else:
@@ -116,9 +115,8 @@ def scan(config, lock, resleep_paths: list, path: str, request_from: str, sectio
         logger.info("Scan request is now being processed...")
         # wait for existing scanners being ran by Plex
         if config["PLEX_WAIT_FOR_EXTERNAL_SCANNERS"] and not wait_plex_scanner(config):
-            # remove item from database if sqlite is enabled
-            if config["SERVER_USE_SQLITE"]:
-                ScanItem.delete_by_path(path)
+            # remove item from database
+            ScanItem.delete_by_path(path)
             return
 
         # run external command before scan if supplied
@@ -134,8 +132,7 @@ def scan(config, lock, resleep_paths: list, path: str, request_from: str, sectio
                 logger.info("Plex is available for media scanning - (Server Account: '%s')", plex_username)
             except Exception:
                 logger.error("Plex is unavailable for media scanning. Aborting scan request for '%s'", path)
-                if config["SERVER_USE_SQLITE"]:
-                    ScanItem.delete_by_path(path)
+                ScanItem.delete_by_path(path)
                 return
 
         # begin scan
@@ -143,8 +140,8 @@ def scan(config, lock, resleep_paths: list, path: str, request_from: str, sectio
         scan_plex_section(config, str(section_id), scan_path=scan_path)
         logger.info("Finished scan!")
 
-        # remove item from Plex database if sqlite is enabled
-        if config["SERVER_USE_SQLITE"] and ScanItem.delete_by_path(path, loglevel=logging.DEBUG):
+        # remove item from Plex database
+        if ScanItem.delete_by_path(path, loglevel=logging.DEBUG):
             logger.info("There are %d queued item(s) remaining.", ScanItem.count())
 
         # empty trash if configured

--- a/autoscan/plex.py
+++ b/autoscan/plex.py
@@ -13,7 +13,8 @@ from plexapi.server import PlexServer
 from plexapi.exceptions import Unauthorized
 from tabulate import tabulate
 
-from autoscan import db, utils
+from autoscan import utils
+from autoscan.db import QueueItemModel
 
 logger = logging.getLogger("PLEX")
 
@@ -90,7 +91,7 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
             logger.warning("File '%s' exhausted all available checks. Aborting scan request.", check_path)
             # remove item from database if sqlite is enabled
             if config["SERVER_USE_SQLITE"]:
-                if db.remove_item(path):
+                if QueueItemModel.delete_by_scan_path(path):
                     logger.info("Removed '%s' from Autoscan database.", path)
                     time.sleep(1)
                 else:
@@ -121,7 +122,7 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
         if config["PLEX_WAIT_FOR_EXTERNAL_SCANNERS"] and not wait_plex_scanner(config):
             # remove item from database if sqlite is enabled
             if config["SERVER_USE_SQLITE"]:
-                if db.remove_item(path):
+                if QueueItemModel.delete_by_scan_path(path):
                     logger.info("Removed '%s' from Autoscan database.", path)
                     time.sleep(1)
                 else:
@@ -142,7 +143,7 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
             except Exception:
                 logger.error("Plex is unavailable for media scanning. Aborting scan request for '%s'", path)
                 if config["SERVER_USE_SQLITE"]:
-                    if db.remove_item(path):
+                    if QueueItemModel.delete_by_scan_path(path):
                         logger.info("Removed '%s' from Autoscan database.", path)
                         time.sleep(1)
                     else:
@@ -156,10 +157,10 @@ def scan(config, lock, path, scan_for, section, scan_type, resleep_paths):
 
         # remove item from Plex database if sqlite is enabled
         if config["SERVER_USE_SQLITE"]:
-            if db.remove_item(path):
+            if QueueItemModel.delete_by_scan_path(path):
                 logger.debug("Removed '%s' from Autoscan database.", path)
                 time.sleep(1)
-                logger.info("There are %d queued item(s) remaining.", db.queued_count())
+                logger.info("There are %d queued item(s) remaining.", QueueItemModel.count_all())
             else:
                 logger.error("Failed removing '%s' from Autoscan database.", path)
 

--- a/autoscan/plex.py
+++ b/autoscan/plex.py
@@ -1,16 +1,16 @@
 import logging
 import os
 import re
+import shlex
 import sqlite3
 import time
 from contextlib import closing
-import shlex
+from copy import copy
 from pathlib import Path
 from typing import List
-from copy import copy
 
-from plexapi.server import PlexServer
 from plexapi.exceptions import Unauthorized
+from plexapi.server import PlexServer
 from tabulate import tabulate
 
 from autoscan import utils

--- a/autoscan/plex.py
+++ b/autoscan/plex.py
@@ -25,7 +25,7 @@ def scan(config, lock, resleep_paths: list, path: str, request_from: str, sectio
 
     # sleep for delay
     while True:
-        logger.info("Scan request from %s for '%s'.", request_from, path)
+        logger.info("Scan request from '%s' for '%s'.", request_from, path)
 
         if scan_delay:
             logger.info("Sleeping for %d seconds...", scan_delay)
@@ -617,10 +617,10 @@ def wait_plex_scanner(config: dict) -> bool:
         running, process, container = utils.is_process_running(scanner_name, plex_container)
         while running and process:
             logger.info(
-                "'%s' is running, pid: %d,%s cmdline: %r. Checking again in 60 seconds...",
+                "'%s' is running, pid: %d, container: %s, cmdline: %r. Checking again in 60 seconds...",
                 process.name(),
                 process.pid,
-                f" container: {container.strip() if use_docker and isinstance(container, str) else ''},",
+                container.strip() if use_docker and isinstance(container, str) else "N/A",
                 process.cmdline(),
             )
             time.sleep(60)

--- a/autoscan/rclone.py
+++ b/autoscan/rclone.py
@@ -1,6 +1,6 @@
-import subprocess
-import os
 import logging
+import os
+import subprocess
 
 logger = logging.getLogger("RCLONE")
 

--- a/autoscan/smi2srt.py
+++ b/autoscan/smi2srt.py
@@ -13,11 +13,11 @@ license: GPL
 # Moonchang Chae님 파일 수정본
 # hojel님의 demux 부분 가져옴 (https://github.com/hojel/SmiConvert.bundle)
 # SJVA, Plex plugin, 쉘 공용
+import logging
 import os
 import re
 import shutil
 import traceback
-import logging
 from pathlib import Path
 
 try:

--- a/autoscan/threads.py
+++ b/autoscan/threads.py
@@ -1,6 +1,6 @@
-import queue
-import datetime
 import copy
+import datetime
+import queue
 import threading
 
 

--- a/autoscan/threads.py
+++ b/autoscan/threads.py
@@ -15,7 +15,6 @@ class PriorityLock:
             # First, just check the lock.
             if self._is_available:
                 self._is_available = False
-                self._mutex.release()
                 return True
             event = threading.Event()
             self._waiter_queue.put((priority, datetime.datetime.now(), event))

--- a/autoscan/utils.py
+++ b/autoscan/utils.py
@@ -47,8 +47,8 @@ def map_file_exists_path_for_rclone(config: dict, path: str) -> str:
     return path
 
 
-def is_server_ignored(config: dict, file_path: str, scan_for: str) -> Tuple[bool, str]:
-    if scan_for not in ["Manual", "Watcher"]:
+def is_server_ignored(config: dict, file_path: str, request_from: str) -> Tuple[bool, str]:
+    if request_from not in ["Manual", "Watcher"]:
         return False, None
     for item in config["SERVER_IGNORE_LIST"]:
         if item.lower() in file_path.lower():

--- a/autoscan/utils.py
+++ b/autoscan/utils.py
@@ -1,15 +1,15 @@
 import logging
 import os
-import subprocess
-from contextlib import closing
-from copy import copy
-from urllib.parse import urljoin
-from pathlib import Path
-from typing import Tuple, Union
 import re
 import shlex
-import xml.etree.ElementTree as ET
 import socket
+import subprocess
+import xml.etree.ElementTree as ET
+from contextlib import closing
+from copy import copy
+from pathlib import Path
+from typing import Tuple, Union
+from urllib.parse import urljoin
 
 import psutil
 import requests


### PR DESCRIPTION
## Important Changes

### 1. Autoscan database migration from legacy to v1

A table name is change from `queueitemmodel` to `scan_item`, which is peewee's new standard. Fields are changes as follows:

|legacy|v1||
|------|---|---|
|scan_path|path||
|scan_for|request_from||
|scan_section|section_id||
|scan_type|event_type||
||created_at|new field|

Variables across functions and threads are also renamed to match with above fields.

### 2. Deprecated `SERVER_USE_SQLITE`

You are force to use Autoscan database whatever you have in your `config.json`. Instead, no default values will be supplied for `--queuefile` arguments in CLI anymore. And thus, you can choose either of an in-memory, handy but no persistent, database or a file-based one with `--queuefile` argument.

## Fixed/Improved

* A thread restoring queue on Autuscan restart will not be initiated anymore if there's nothing to restore
* Initialize DB from main module for administration purpose
