### PR TITLE
fixes issue #18

### DIFF
--- a/autoscan/db.py
+++ b/autoscan/db.py
@@ -35,7 +35,9 @@ class ScanItem(BaseModel):
             logger.warning(
                 "You are using an in-memory database as Autoscan queue. Consider using a file-based one by specifying `--queuefile` arg in CLI."
             )
-        database = pw.SqliteDatabase(path)
+            database = pw.SqliteDatabase(path,thread_safe=False,check_same_thread=False)
+        else:
+            database = pw.SqliteDatabase(path)
         ScanItem.migrate_from_legacy_to_v1(database)
         cls.bind(database)
         if not os.path.exists(path) or not cls.table_exists():


### PR DESCRIPTION
In-memory databases only exist for the connection that opened them. Peewee, by default, uses a connection-per-thread, so each thread has it's own connection (and hence its own in-memory database).